### PR TITLE
Fix issue with trickle

### DIFF
--- a/less/trickle.less
+++ b/less/trickle.less
@@ -1,5 +1,6 @@
 .extension-trickle {
   text-align: center;
+  display:none;
 
   .trickle-button {
     display:none;


### PR DESCRIPTION
On completing blocks in an article, going back to the menu and returning back to the article the trickle element is still visible. 
In the current Adapt develop branch is hard to notice this, but if you inspect the element you will notice that the following div is visible.
<div class="extension-trickle"></div>

This line prevent this from happening.